### PR TITLE
Move back to using onEvent

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export async function exportEvents(event, meta) {
+export async function onEvent(event, meta) {
     const api_key = meta.config.api_key
     const raw = JSON.stringify({
         data: event,


### PR DESCRIPTION
We're moving exports to a new system, so the exportEvents function won't be available in the apps anymore.
Historical context https://posthoghelp.zendesk.com/agent/tickets/983 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/3903) we suggested exportEvents in the review and it was originally onEvent