### PR TITLE
don't send $ properties

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,12 @@ const plugin: Plugin<PaceMetaInput> = {
                 'x-api-key': config.api_key,
             },
             body: JSON.stringify({
-                data: event,
+                data: {
+                    ...event,
+                    properties: Object.fromEntries(
+                        Object.entries(event.properties || {}).filter(([key, _]) => !key.startsWith('$'))
+                    ),
+                },
             }),
             method: 'POST',
         } as Webhook),

--- a/test/test.ts
+++ b/test/test.ts
@@ -77,6 +77,20 @@ describe('plugin tests', () => {
             'x-api-key': 'i-am-an-api-key',
         })
         expect(webhook1).toHaveProperty('method', 'POST')
-        expect(webhook1).toHaveProperty('body', JSON.stringify({ data: mockEvent }))
+        expect(webhook1).toHaveProperty(
+            'body',
+            JSON.stringify({
+                data: {
+                    uuid: '10000000-0000-4000-0000-000000000000',
+                    team_id: 1,
+                    distinct_id: '1234',
+                    event: 'my-event',
+                    timestamp: mockEvent.timestamp,
+                    properties: {
+                        foo: 'bar',
+                    },
+                },
+            })
+        )
     })
 })


### PR DESCRIPTION
e.g. $elements_chain can be really big, which can lead to the payload becoming too big and event being dropped not sent